### PR TITLE
chore(transfer): 管理系統をOrganizationに移譲

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Node製の静的サイトジェネレーター(Static Site Generator)です。
 
 [![npm version](https://badgen.net/npm/v/custom-site)](https://npm.im/custom-site)
-[![Build Status](https://travis-ci.org/Himenon/custom-site.svg?branch=develop)](https://travis-ci.org/Himenon/custom-site)
-[![codecov](https://codecov.io/gh/Himenon/custom-site/branch/develop/graph/badge.svg)](https://codecov.io/gh/Himenon/custom-site)
-[![dependencies Status](https://david-dm.org/Himenon/custom-site/status.svg)](https://david-dm.org/Himenon/custom-site)
-[![devDependencies Status](https://david-dm.org/Himenon/custom-site/dev-status.svg)](https://david-dm.org/Himenon/custom-site?type=dev)
+[![Build Status](https://travis-ci.com/custom-site/custom-site.svg?branch=develop)](https://travis-ci.com/custom-site/custom-site)
+[![codecov](https://codecov.io/gh/custom-site/custom-site/branch/develop/graph/badge.svg)](https://codecov.io/gh/custom-site/custom-site)
+[![dependencies Status](https://david-dm.org/custom-site/custom-site/status.svg)](https://david-dm.org/custom-site/custom-site)
+[![devDependencies Status](https://david-dm.org/custom-site/custom-site/dev-status.svg)](https://david-dm.org/custom-site/custom-site?type=dev)
 
 ## 使い方
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "custom-site",
+  "name": "@custom-site/custom-site",
   "version": "0.1.1",
   "description": "Static Site Generator",
   "keywords": [
@@ -27,7 +27,8 @@
     "custom-site": "./lib/cli.js"
   },
   "directories": {
-    "lib": "lib"
+    "lib": "lib",
+    "example": "example"
   },
   "scripts": {
     "build": "yarn run clean && tsc -p ./tsconfig.build.json",
@@ -120,5 +121,8 @@
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.2.2",
     "yarn-outdated-notifier": "^1.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "template",
     "typescript"
   ],
-  "homepage": "https://github.com/Himenon/custom-site#readme",
+  "homepage": "https://github.com/custom-site/custom-site#readme",
   "bugs": {
-    "url": "https://github.com/Himenon/custom-site/issues"
+    "url": "https://github.com/custom-site/custom-site/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Himenon/custom-site.git"
+    "url": "git+https://github.com/custom-site/custom-site.git"
   },
   "license": "MIT",
   "author": "Himenon",


### PR DESCRIPTION
* `travis-ci.org`から`travis-ci.com`へ変更（環境変数）
* codecovの設定変更（環境変数）
* パッケージ名、リリース先を`custom-site`から`@custom-site/custom-site`へ変更
* 各種バッジのリンクを変更
* `custom-site`はdeprecatedにした
