### PR TITLE
feat(extend): Extend Head tag parameter and Plugin

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,5 @@
 {
-    "automock": true,
+    "automock": false,
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/*"
     ],

--- a/src/__tests__/SiteExample.ts
+++ b/src/__tests__/SiteExample.ts
@@ -1,0 +1,36 @@
+import { PageState, SiteState } from "@custom-site/page";
+
+export const siteStateExample: SiteState = {
+  title: "test site",
+  description: "test description",
+  url: {
+    relativePath: "/test",
+    absolutePath: "http://example.com",
+  },
+  basePath: "/test",
+};
+
+export const pageStateExamples: PageState[] = [
+  {
+    uri: "/a",
+    content: "test page a",
+    metaData: {
+      title: "test page title a",
+    },
+    ext: ".mdx",
+    filename: "a.mdx",
+    name: "a",
+    raw: "test page",
+  },
+  {
+    uri: "/b",
+    content: "test page b",
+    metaData: {
+      title: "test page title b",
+    },
+    ext: ".mdx",
+    filename: "b.mdx",
+    name: "b",
+    raw: "test page",
+  },
+];

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -1,0 +1,54 @@
+import { pluginEventEmitter } from "../plugin";
+import { render } from "../renderer";
+import { pageStateExamples, siteStateExample } from "./SiteExample";
+
+describe("render test", () => {
+  test("no pages", async done => {
+    const pages = await render(siteStateExample, []);
+    expect(pages.length).toBe(0);
+    done();
+  });
+
+  test("sample page", async done => {
+    const pages = await render(siteStateExample, [pageStateExamples[0]]);
+    expect(pages.length).toBe(1);
+    expect(pages[0].html).toBe(
+      // tslint:disable-next-line:max-line-length
+      '<html><head lang="en"><title>test page title a</title><meta charSet="utf-8"/></head><body><div><p>test page a</p></div></body></html>',
+    );
+    done();
+  });
+
+  test("meta plugin", async done => {
+    pluginEventEmitter.on("GENERATE_META_DATA", payload => {
+      payload.page.metaData.extend = {
+        meta: [
+          {
+            property: "og:title",
+            content: payload.page.metaData.title,
+          },
+          {
+            name: "twitter:site",
+            content: "@twitter",
+          },
+        ],
+      };
+      return payload;
+    });
+    const pages = await render(siteStateExample, [pageStateExamples[1]]);
+    expect(pages.length).toBe(1);
+    expect(pages[0].html).toMatch(/og:title/);
+    expect(pages[0].html).toMatch(/twitter:site/);
+    done();
+  });
+
+  test("empty plugin", async done => {
+    pluginEventEmitter.on("AFTER_RENDER_PAGE", _payload => {
+      return { html: "rewrite result" };
+    });
+    const pages = await render(siteStateExample, [pageStateExamples[1]]);
+    expect(pages.length).toBe(1);
+    expect(pages[0].html).toBe("rewrite result");
+    done();
+  });
+});

--- a/src/lifeCycle.ts
+++ b/src/lifeCycle.ts
@@ -22,6 +22,7 @@ export const initPlugins = () => {
       return;
     }
     pluginEventEmitter.on("GENERATE_META_DATA", externalPlugin.onGenerateMetaData);
+    pluginEventEmitter.on("AFTER_RENDER_PAGE", externalPlugin.onAfterRenderPage);
   });
 };
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,6 +1,7 @@
 import { ExternalCustomComponent, ExternalTemplate, PageState, RenderedStaticPage, SiteState } from "@custom-site/page";
 import { CustomComponents } from "@mdx-js/tag";
 import * as path from "path";
+import { renderToStaticMarkup } from "react-dom/server";
 import { createTemplateHOC } from "./createTemplate";
 import { loadExternalFunction } from "./importer";
 import { pluginEventEmitter } from "./plugin";
@@ -66,13 +67,20 @@ const createBody = (page: PageState, site: SiteState) => {
  */
 const createRenderPage = (site: SiteState) => (page: PageState): RenderedStaticPage => {
   const applyTemplate = createTemplate(site, page);
-  return {
-    name: path.join(site.basePath, page.name),
-    originalName: page.name,
-    html: combine({
+  const id = `AFTER_RENDER_PAGE/${page.uri}`;
+  const html = renderToStaticMarkup(
+    combine({
       head: createHead(site, page),
       body: applyTemplate(createBody(page, site)),
     }),
+  );
+  const state = { id, html };
+  pluginEventEmitter.emit("AFTER_RENDER_PAGE", state);
+  const result = plugin.get({ type: "AFTER_RENDER_PAGE", id }, state).html;
+  return {
+    name: path.join(site.basePath, page.name),
+    originalName: page.name,
+    html: result,
   };
 };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,6 +5,9 @@ interface State {
   [id: string]: any;
 }
 
+/**
+ * TODO clear
+ */
 export class Store<U extends {}> {
   private state: State = {};
   public set<T extends keyof U>(params: { type: T; id: string; state: U[T] }): void {

--- a/src/transformer/__tests__/createHeadContent.test.tsx
+++ b/src/transformer/__tests__/createHeadContent.test.tsx
@@ -1,14 +1,100 @@
 jest.unmock("../createHeadContent.tsx");
+jest.unmock("../tags/generateScriptElements.tsx");
+jest.unmock("../tags/generateLinkElements.tsx");
+import * as React from "react";
 import * as ReactDOM from "react-dom/server";
-import { generateViewportMetaElements } from "../createHeadContent";
+import { convertMetaHTMLAttributes, createHeadContent, generateMetaElements, generateViewportMetaAttributes } from "../createHeadContent";
 
 describe("Create Head Content Test", () => {
   test("generateViewportMetaTag", () => {
-    const vdom = generateViewportMetaElements({
+    const props = generateViewportMetaAttributes({
       viewport: {
         "initial-scale": "1.0",
       },
     });
-    expect(ReactDOM.renderToStaticMarkup(vdom!)).toBe(`<meta name="viewport" content="initial-scale=1.0"/>`);
+    expect(ReactDOM.renderToStaticMarkup(<meta {...props} />)).toBe(`<meta name="viewport" content="initial-scale=1.0"/>`);
+  });
+
+  test("generateMetaElements length", () => {
+    const elements = generateMetaElements([]);
+    expect(elements.length).toBe(0);
+  });
+
+  test("extend twitter card", () => {
+    const elements = generateMetaElements([
+      {
+        name: "twitter:card",
+        content: "summary",
+      },
+      {
+        name: "twitter:site",
+        content: "@twitter",
+      },
+    ]);
+    expect(ReactDOM.renderToStaticMarkup(elements[0])).toBe('<meta name="twitter:card" content="summary"/>');
+    expect(ReactDOM.renderToStaticMarkup(elements[1])).toBe('<meta name="twitter:site" content="@twitter"/>');
+  });
+
+  test("charSet test", () => {
+    const props = convertMetaHTMLAttributes({});
+    expect(props.length).toBe(1);
+    expect(props[0].key).toBe("charset");
+    expect(props[0].charSet).toBe("utf-8");
+  });
+
+  test("extend parameter", () => {
+    const extendParameter = {
+      name: "twitter:card",
+      content: "summary",
+    };
+    const props = convertMetaHTMLAttributes({
+      extend: {
+        meta: [
+          {
+            name: "twitter:card",
+            content: "summary",
+          },
+        ],
+      },
+    });
+    expect(props.length).toBe(2);
+    expect(props[1].name).toEqual(extendParameter.name);
+    expect(props[1].content).toEqual(extendParameter.content);
+  });
+
+  test("createHeadContent default params render", () => {
+    const element = createHeadContent({});
+    expect(ReactDOM.renderToStaticMarkup(element)).toBe('<head lang="en"><title></title><meta charSet="utf-8"/></head>');
+  });
+
+  test("createHeadContent extend script", () => {
+    const element = createHeadContent({
+      extend: {
+        script: [
+          {
+            src: "/extends/c.js",
+          },
+        ],
+      },
+    });
+    expect(ReactDOM.renderToStaticMarkup(element)).toBe(
+      '<head lang="en"><title></title><meta charSet="utf-8"/><script src="/extends/c.js"></script></head>',
+    );
+  });
+
+  test("createHeadContent extend script", () => {
+    const element = createHeadContent({
+      extend: {
+        link: [
+          {
+            rel: "stylesheet",
+            href: "/extends/c.css",
+          },
+        ],
+      },
+    });
+    expect(ReactDOM.renderToStaticMarkup(element)).toBe(
+      '<head lang="en"><title></title><meta charSet="utf-8"/><link rel="stylesheet" href="/extends/c.css"/></head>',
+    );
   });
 });

--- a/src/transformer/combine.tsx
+++ b/src/transformer/combine.tsx
@@ -1,18 +1,15 @@
 import * as React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 
 export interface ElementMap {
   head: React.ReactElement<any>;
   body: React.ReactElement<any>;
 }
 
-export const combine = (elements: ElementMap): string => {
-  const page = (
+export const combine = (elements: ElementMap): React.ReactElement<any> => {
+  return (
     <html>
       {elements.head}
       {elements.body}
     </html>
   );
-
-  return renderToStaticMarkup(page);
 };

--- a/src/transformer/createHeadContent.tsx
+++ b/src/transformer/createHeadContent.tsx
@@ -28,6 +28,8 @@ export const createHeadContent = (htmlMetaData: HtmlMetaData): React.ReactElemen
       {htmlMetaData["og:description"] && <meta property="og:description" content={htmlMetaData["og:description"]} />}
       {htmlMetaData["og:image"] && <meta property="og:image" content={htmlMetaData["og:image"]} />}
       {htmlMetaData["og:url"] && <meta property="og:url" content={htmlMetaData["og:url"]} />}
+      {htmlMetaData["twitter:site"] && <meta property="twitter:site" content={htmlMetaData["twitter:site"]} />}
+      {htmlMetaData["twitter:card"] && <meta property="twitter:card" content={htmlMetaData["twitter:card"]} />}
       {generateViewportMetaElements(htmlMetaData)}
       {generateScriptElements(htmlMetaData)}
       {generateLinkElements(htmlMetaData)}

--- a/src/transformer/createHeadContent.tsx
+++ b/src/transformer/createHeadContent.tsx
@@ -1,36 +1,81 @@
-import { HtmlMetaData } from "@custom-site/page";
+import { HtmlMetaData, MetaHTMLAttributes } from "@custom-site/page";
 import * as React from "react";
 import { generateGoogleAnalyticsElement } from "./tags/generateGoogleAnalyticsElement";
 import { generateLinkElements } from "./tags/generateLinkElements";
 import { generateScriptElements } from "./tags/generateScriptElements";
 
-export const generateViewportMetaElements = ({ viewport }: HtmlMetaData): JSX.Element | undefined => {
+export const generateViewportMetaAttributes = ({ viewport }: HtmlMetaData): MetaHTMLAttributes | undefined => {
   if (!viewport) {
     return;
   }
   const content = Object.keys(viewport)
     .map(key => `${key}=${viewport[key]}`)
     .join(",");
-  return <meta name="viewport" content={content} />;
+  return {
+    name: "viewport",
+    content,
+  };
+};
+
+/**
+ * Merge shortcut parameter and extendable parameter
+ */
+export const convertMetaHTMLAttributes = (htmlMetaData: HtmlMetaData): MetaHTMLAttributes[] => {
+  const viewport = generateViewportMetaAttributes(htmlMetaData);
+  return [
+    {
+      key: "charset",
+      charSet: "utf-8",
+    },
+    ...(htmlMetaData.keywords
+      ? [
+          {
+            name: "keywords",
+            content: htmlMetaData.keywords,
+          },
+        ]
+      : []),
+    ...(htmlMetaData.description
+      ? [
+          {
+            name: "description",
+            content: htmlMetaData.description,
+          },
+        ]
+      : []),
+    ...(htmlMetaData.copyright
+      ? [
+          {
+            name: "copyright",
+            content: htmlMetaData.copyright,
+          },
+        ]
+      : []),
+    ...(htmlMetaData.author
+      ? [
+          {
+            name: "author",
+            content: htmlMetaData.author,
+          },
+        ]
+      : []),
+    ...(htmlMetaData.extend && htmlMetaData.extend.meta ? htmlMetaData.extend.meta : []),
+    ...(viewport ? [viewport] : []),
+  ];
+};
+
+export const generateMetaElements = (props: MetaHTMLAttributes[]): Array<React.ReactElement<any>> => {
+  return props.map((prop, idx) => <meta {...prop} key={`meta-${idx}`} />);
 };
 
 export const createHeadContent = (htmlMetaData: HtmlMetaData): React.ReactElement<any> => {
   const thirdParty = htmlMetaData.thirdParty;
+  const metaAttributes = convertMetaHTMLAttributes(htmlMetaData);
   return (
     <head lang={htmlMetaData.lang || "en"}>
       <title>{htmlMetaData.title}</title>
-      <meta key="charset" charSet="utf-8" />
-      {htmlMetaData.keywords && <meta name="keywords" content={htmlMetaData.keywords} />}
-      {htmlMetaData.description && <meta name="description" content={htmlMetaData.description} />}
-      {htmlMetaData.copyright && <meta name="copyright" content={htmlMetaData.copyright} />}
-      {htmlMetaData.author && <meta name="author" content={htmlMetaData.author} />}
-      {htmlMetaData["og:title"] && <meta property="og:title" content={htmlMetaData["og:title"]} />}
-      {htmlMetaData["og:description"] && <meta property="og:description" content={htmlMetaData["og:description"]} />}
-      {htmlMetaData["og:image"] && <meta property="og:image" content={htmlMetaData["og:image"]} />}
-      {htmlMetaData["og:url"] && <meta property="og:url" content={htmlMetaData["og:url"]} />}
-      {htmlMetaData["twitter:site"] && <meta property="twitter:site" content={htmlMetaData["twitter:site"]} />}
-      {htmlMetaData["twitter:card"] && <meta property="twitter:card" content={htmlMetaData["twitter:card"]} />}
-      {generateViewportMetaElements(htmlMetaData)}
+      {generateMetaElements(metaAttributes)}
+      {generateViewportMetaAttributes(htmlMetaData)}
       {generateScriptElements(htmlMetaData)}
       {generateLinkElements(htmlMetaData)}
       {thirdParty && thirdParty.googleAnalytics && generateGoogleAnalyticsElement(thirdParty.googleAnalytics)}

--- a/src/transformer/tags/__tests__/generateScriptElements.test.tsx
+++ b/src/transformer/tags/__tests__/generateScriptElements.test.tsx
@@ -27,9 +27,17 @@ describe("Script Element", () => {
         },
         {},
       ],
+      extend: {
+        script: [
+          {
+            src: "/extends/a.js",
+          },
+        ],
+      },
     });
     expect(domString).toBe(
-      '<head><script src="/a.js"></script><script src="./a/b/c.js"></script><script async="" src="./a/b/d.js"></script></head>',
+      // tslint:disable-next-line:max-line-length
+      '<head><script src="/a.js"></script><script src="./a/b/c.js"></script><script async="" src="./a/b/d.js"></script><script src="/extends/a.js"></script></head>',
     );
   });
 

--- a/src/transformer/tags/generateLinkElements.tsx
+++ b/src/transformer/tags/generateLinkElements.tsx
@@ -43,7 +43,7 @@ const getMakeTag = (dryParameter: DryCheckParameter[] = []) => (
   return <link {...{ ...attributes }} key={attributes.href} />;
 };
 
-export const generateLinkElements = ({ localLinks, globalLinks }: HtmlMetaData): JSX.Element[] => {
+export const generateLinkElements = ({ localLinks, globalLinks, extend }: HtmlMetaData): JSX.Element[] => {
   const elements: JSX.Element[] = [];
   const makeTag = getMakeTag();
   if (globalLinks) {
@@ -57,6 +57,14 @@ export const generateLinkElements = ({ localLinks, globalLinks }: HtmlMetaData):
   if (localLinks) {
     localLinks.forEach(attribute => {
       const tagElement = makeTag(attribute, true);
+      if (tagElement) {
+        elements.push(tagElement);
+      }
+    });
+  }
+  if (extend && extend.link) {
+    extend.link.forEach(attribute => {
+      const tagElement = makeTag(attribute, false);
       if (tagElement) {
         elements.push(tagElement);
       }

--- a/src/transformer/tags/generateScriptElements.tsx
+++ b/src/transformer/tags/generateScriptElements.tsx
@@ -40,10 +40,10 @@ const getMakeScriptTag = (dryParameter: DryCheckParameter[] = []) => (
       isLocal,
     });
   }
-  return <script {...{ ...attributes, src: attributes.src }} key={attributes.src} />;
+  return <script {...{ ...attributes }} key={attributes.src} />;
 };
 
-export const generateScriptElements = ({ localScripts, globalScripts }: HtmlMetaData): JSX.Element[] => {
+export const generateScriptElements = ({ localScripts, globalScripts, extend }: HtmlMetaData): JSX.Element[] => {
   const elements: JSX.Element[] = [];
   const makeScriptTag = getMakeScriptTag();
   if (globalScripts) {
@@ -57,6 +57,14 @@ export const generateScriptElements = ({ localScripts, globalScripts }: HtmlMeta
   if (localScripts) {
     localScripts.forEach(attribute => {
       const tagElement = makeScriptTag(attribute, true);
+      if (tagElement) {
+        elements.push(tagElement);
+      }
+    });
+  }
+  if (extend && extend.script) {
+    extend.script.forEach(attribute => {
+      const tagElement = makeScriptTag(attribute, false);
       if (tagElement) {
         elements.push(tagElement);
       }

--- a/typings/@custom-site/index.d.ts
+++ b/typings/@custom-site/index.d.ts
@@ -11,6 +11,8 @@ declare module "@custom-site/plugin" {
   export interface State {
     /** Return Value only Use page.metaData */
     GENERATE_META_DATA: { site: SiteState; page: PageState };
+    /** Render Page converter */
+    AFTER_RENDER_PAGE: { html: string };
   }
 
   export type CreateHandlerMap<T> = { [P in keyof T]?: Array<(payload: T[P]) => T[P]> };
@@ -19,6 +21,7 @@ declare module "@custom-site/plugin" {
 
   export interface PluginFunctionMap {
     onGenerateMetaData?: CreateHandler<"GENERATE_META_DATA">;
+    onAfterRenderPage?: CreateHandler<"AFTER_RENDER_PAGE">;
   }
 
   export interface PluginDetail {
@@ -101,11 +104,13 @@ declare module "@custom-site/config" {
 declare module "@custom-site/page" {
   import { CustomComponents } from "@mdx-js/tag";
 
+  // TODO Plugin
   export interface TwitterMeta {
     "twitter:card"?: "summary" | "summary_large_image";
     "twitter:site"?: string;
   }
 
+  // TODO Plugin
   export interface OGP {
     "og:title"?: string;
     "og:description"?: string;
@@ -113,9 +118,11 @@ declare module "@custom-site/page" {
     "og:image"?: string;
   }
 
-  export type ScriptHTMLAttributes = React.ScriptHTMLAttributes<HTMLScriptElement>;
+  export type ScriptHTMLAttributes = JSX.IntrinsicElements["script"];
 
-  export type LinkHTMLAttributes = React.LinkHTMLAttributes<HTMLLinkElement>;
+  export type LinkHTMLAttributes = JSX.IntrinsicElements["link"];
+
+  export type MetaHTMLAttributes = JSX.IntrinsicElements["meta"];
 
   export interface ExternalJavaScript {
     js?: Array<string | ScriptHTMLAttributes>;
@@ -139,7 +146,10 @@ declare module "@custom-site/page" {
     };
   }
 
-  export interface HtmlMetaData extends OGP, TwitterMeta, ExternalJavaScript, ExternalCSS, ExternalLink {
+  export interface HtmlMetaData extends ExternalJavaScript, ExternalCSS, ExternalLink {
+    /**
+     * Default Support Meta Property Set
+     */
     lang?: string;
     description?: string;
     keywords?: string;
@@ -154,6 +164,14 @@ declare module "@custom-site/page" {
       "minimum-scale"?: number | string;
       "user-scalable"?: "no";
       width?: number | "device-width";
+    };
+    /**
+     * Extendable Meta Property Parameters
+     */
+    extend?: {
+      meta?: MetaHTMLAttributes[];
+      script?: ScriptHTMLAttributes[];
+      link?: LinkHTMLAttributes[];
     };
     thirdParty?: ThirdParty;
   }


### PR DESCRIPTION
## これはなに

* [x] Headタグの中身を拡張する機構

## どのように解決するか

* [x] `htmlMetaData.extend` を掘った

## 確認事項

* [x] 自己レビューした
* [x] CIが通った

## バージョン

* [x] Major: 後方互換性のない変更を含む
* [ ] Minor: 後方互換性があり機能を追加した
* [ ] Patch: 後方互換性があり、新規実装を含まないバグ修正を行った

Ref: [セマンティック バージョニング](https://semver.org/lang/ja/)
