### PR TITLE
feat(csr-props): add initial props to client side

### DIFF
--- a/src/__tests__/getLayout.test.tsx
+++ b/src/__tests__/getLayout.test.tsx
@@ -38,15 +38,15 @@ describe("rendering test", () => {
     const wrapper = createTemplateHOC({ postProps: pageProps });
     const element = wrapper(<div>{"hello"}</div>);
     const result = ReactDOM.renderToStaticMarkup(element);
-    expect(result).toBe("<body><div>hello</div></body>");
+    expect(result).toBe("<div>hello</div>");
   });
 
   test("custom template", () => {
     const applyLayout = (_props: PostProps) => (content?: React.ReactNode): React.ReactElement<any> => {
       return (
-        <body id="my-template">
-          <main>{content}</main>
-        </body>
+        <>
+          <main id="my-template">{content}</main>
+        </>
       );
     };
     const wrapper = createTemplateHOC({
@@ -55,6 +55,6 @@ describe("rendering test", () => {
     });
     const element = wrapper(<div>{"hello"}</div>);
     const result = ReactDOM.renderToStaticMarkup(element);
-    expect(result).toBe('<body id="my-template"><main><div>hello</div></main></body>');
+    expect(result).toBe('<main id="my-template"><div>hello</div></main>');
   });
 });

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -12,10 +12,10 @@ describe("render test", () => {
   test("sample page", async done => {
     const pages = await render(siteStateExample, [pageStateExamples[0]]);
     expect(pages.length).toBe(1);
-    expect(pages[0].html).toBe(
-      // tslint:disable-next-line:max-line-length
-      '<html><head lang="en"><title>test page title a</title><meta charSet="utf-8"/></head><body><div><p>test page a</p></div></body></html>',
-    );
+    expect(pages[0].html).toMatch(/<title>test page title a<\/title>/);
+    expect(pages[0].html).toMatch(/<meta charSet="utf-8"\/>/);
+    expect(pages[0].html).toMatch(/<head lang="en">/);
+    expect(pages[0].html).toMatch(/<body><div><p>test page a<\/p><\/div><\/body>/);
     done();
   });
 

--- a/src/createTemplate.tsx
+++ b/src/createTemplate.tsx
@@ -8,7 +8,7 @@ export const createTemplateComponent = (props: TemplateProps) => {
       if (applyTemplate) {
         return applyTemplate(this.props.children);
       }
-      return <body>{this.props.children}</body>;
+      return <>{this.props.children}</>;
     }
   };
 };

--- a/src/transformer/__tests__/createHeadContent.test.tsx
+++ b/src/transformer/__tests__/createHeadContent.test.tsx
@@ -64,7 +64,8 @@ describe("Create Head Content Test", () => {
 
   test("createHeadContent default params render", () => {
     const element = createHeadContent({});
-    expect(ReactDOM.renderToStaticMarkup(element)).toBe('<head lang="en"><title></title><meta charSet="utf-8"/></head>');
+    const result = ReactDOM.renderToStaticMarkup(element);
+    expect(result).toMatch('<title></title><meta charSet="utf-8"/>');
   });
 
   test("createHeadContent extend script", () => {
@@ -77,9 +78,9 @@ describe("Create Head Content Test", () => {
         ],
       },
     });
-    expect(ReactDOM.renderToStaticMarkup(element)).toBe(
-      '<head lang="en"><title></title><meta charSet="utf-8"/><script src="/extends/c.js"></script></head>',
-    );
+    const result = ReactDOM.renderToStaticMarkup(element);
+    expect(result).toMatch(/<meta charSet="utf-8"\/>/);
+    expect(result).toMatch(/<script src="\/extends\/c.js">/);
   });
 
   test("createHeadContent extend script", () => {

--- a/src/transformer/combine.tsx
+++ b/src/transformer/combine.tsx
@@ -1,15 +1,33 @@
+import { HtmlMetaData, PageState, SiteState } from "@custom-site/page";
 import * as React from "react";
 
-export interface ElementMap {
+export interface ViewProps {
+  csrProps: {
+    htmlMetaData: HtmlMetaData;
+    site: SiteState;
+    page: PageState;
+  };
   head: React.ReactElement<any>;
   body: React.ReactElement<any>;
 }
 
-export const combine = (elements: ElementMap): React.ReactElement<any> => {
+const generateCsrInitialPropsScript = (csrProps: ViewProps["csrProps"]) => {
+  const props: JSX.IntrinsicElements["script"] = {
+    dangerouslySetInnerHTML: {
+      __html: `window.__INITIAL_PROPS__ = ${JSON.stringify(csrProps)}`,
+    },
+  };
+  return <script {...props} />;
+};
+
+export const combine = (viewProps: ViewProps): React.ReactElement<any> => {
   return (
     <html>
-      {elements.head}
-      {elements.body}
+      <head lang={viewProps.csrProps.htmlMetaData.lang || "en"}>
+        {viewProps.head}
+        {generateCsrInitialPropsScript(viewProps.csrProps)}
+      </head>
+      <body>{viewProps.body}</body>
     </html>
   );
 };

--- a/src/transformer/combine.tsx
+++ b/src/transformer/combine.tsx
@@ -11,21 +11,12 @@ export interface ViewProps {
   body: React.ReactElement<any>;
 }
 
-const generateCsrInitialPropsScript = (csrProps: ViewProps["csrProps"]) => {
-  const props: JSX.IntrinsicElements["script"] = {
-    dangerouslySetInnerHTML: {
-      __html: `window.__INITIAL_PROPS__ = ${JSON.stringify(csrProps)}`,
-    },
-  };
-  return <script {...props} />;
-};
-
 export const combine = (viewProps: ViewProps): React.ReactElement<any> => {
   return (
     <html>
       <head lang={viewProps.csrProps.htmlMetaData.lang || "en"}>
         {viewProps.head}
-        {generateCsrInitialPropsScript(viewProps.csrProps)}
+        <script id="csr-props" data-csr-props={JSON.stringify(viewProps.csrProps)} />
       </head>
       <body>{viewProps.body}</body>
     </html>

--- a/src/transformer/createHeadContent.tsx
+++ b/src/transformer/createHeadContent.tsx
@@ -72,12 +72,12 @@ export const createHeadContent = (htmlMetaData: HtmlMetaData): React.ReactElemen
   const thirdParty = htmlMetaData.thirdParty;
   const metaAttributes = convertMetaHTMLAttributes(htmlMetaData);
   return (
-    <head lang={htmlMetaData.lang || "en"}>
+    <>
       <title>{htmlMetaData.title}</title>
       {generateMetaElements(metaAttributes)}
       {generateScriptElements(htmlMetaData)}
       {generateLinkElements(htmlMetaData)}
       {thirdParty && thirdParty.googleAnalytics && generateGoogleAnalyticsElement(thirdParty.googleAnalytics)}
-    </head>
+    </>
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "target": "esnext",
     "lib": [
-      "dom",
       "esnext"
     ],
     "experimentalDecorators": true,


### PR DESCRIPTION
## これはなに

* [x] Client SideにPropsを渡す

## どのように解決するか

* [x] `window.__INITIAL_PROPS__` に刺す

## 確認事項

* [ ] 自己レビューした
* [ ] CIが通った

## バージョン

* [ ] Major: 後方互換性のない変更を含む
* [ ] Minor: 後方互換性があり機能を追加した
* [ ] Patch: 後方互換性があり、新規実装を含まないバグ修正を行った

Ref: [セマンティック バージョニング](https://semver.org/lang/ja/)
